### PR TITLE
fix version string

### DIFF
--- a/finetuning-surrogates/setup.py
+++ b/finetuning-surrogates/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=long_desc,
     long_description_content_type='text/markdown',
     install_requires=install_requires,
-    python_requires=">=3.8.*",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Currently running `conda env create -f environment.yml` results in an installation error due to version string in `finetuning-surrogates/setup.py`:
```
Pip subprocess error:
  Running command git clone --filter=blob:none --quiet https://github.com/exalearn/nfp.git /tmp/pip-req-build-8bmwnvgu
  Running command git checkout -b gc_updates --track origin/gc_updates
  Switched to a new branch 'gc_updates'
  branch 'gc_updates' set up to track 'origin/gc_updates'.
  error: subprocess-exited-with-error
 
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in fff setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.8.*'
      [end of output]
 
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```
This fix results in successful installation.